### PR TITLE
Add ApprovalToAPB class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.ruby-version
+.ruby-gemset

--- a/README.md
+++ b/README.md
@@ -44,11 +44,11 @@ Since this tool is used in conjunction the apb tool the recommended steps are
 2. cd <<service_template_name_converted_to_apb_format>>
 
 **To convert service template based on the href **
-3. ruby <<your_git_dir>>/miq_apb_tool/service_template_to_apb.rb -n -r https://<<cfme_server>/api/service_templates/1
+3. ruby <<your_git_dir>>/miq_apb_tool/miq_apb.rb -n -r https://<<cfme_server>/api/service_templates/1
 
 **To convert based on the service template name**
 
-ruby <<your_git_dir>>/miq_apb_tool/service_template_to_apb.rb -n -t CFME_RHEV
+ruby <<your_git_dir>>/miq_apb_tool/miq_apb.rb -n -t CFME_RHEV
 
 
 ** Now we are back to using the apb tool

--- a/approval_to_apb.rb
+++ b/approval_to_apb.rb
@@ -1,0 +1,30 @@
+class ApprovalToAPB
+
+  def initialize(options)
+    @source_dir = File.dirname(__FILE__)
+  end
+
+  def convert
+    install_role_from_template
+    place_role_in_playbook
+  end
+
+  def place_role_in_playbook
+    filename = "playbooks/provision.yml"
+    raise "playbooks/provision.yml not found" unless File.exist?(filename)
+    provision_playbook = YAML.load_file(filename)
+    if provision_playbook[0]['roles'][2]['role'] == 'manageiq-approval'
+      puts "Approval Role found, skipping..."
+    else
+      provision_playbook[0]['roles'].insert(2, {'role' => 'manageiq-approval', 'any_errors_fatal' => true })
+      puts "Overwriting #{filename}"
+      File.delete(filename) if File.exist?(filename)
+      File.write(filename, provision_playbook.to_yaml)
+    end
+  end
+
+  def install_role_from_template
+    puts "Copying over manageiq-approval role"
+    FileUtils.copy_entry "#{@source_dir}/role_templates/manageiq-approval", "./roles/manageiq-approval"
+  end
+end

--- a/miq_apb.rb
+++ b/miq_apb.rb
@@ -1,0 +1,71 @@
+##!/usr/env ruby
+#
+
+require 'optparse'
+require_relative 'service_template_parameters'
+require_relative 'service_template'
+require_relative 'service_template_to_apb'
+require_relative 'approval_to_apb'
+
+options = {:user          => "admin",
+           :password      => "smartvm",
+           :verify_ssl    => true,
+           :quota_check   => false,
+           :api_url       => "http://localhost:4000"}
+
+parser = OptionParser.new do|opts|
+  opts.banner = "Converts Cloudforms service template to APB.\nUsage: miq_apb.rb [options]"
+  opts.on('-u', '--user <<user>>', 'CFME User default: admin') do |user|
+    options[:user] = user
+  end
+
+  opts.on('-p', '--password <<password>>', 'CFME Password default: smartvm') do |password|
+    options[:password] = password
+  end
+
+  opts.on('-s', '--url <<url>>', 'CFME Server URL default: http://localhost:4000') do |url|
+    options[:url] = url
+  end
+
+  opts.on('-t', '--template <<name>>', 'Service Template e.g. CFME_RHEV') do |template|
+    options[:template] = template
+  end
+
+  opts.on('-r', '--template_href <<url>>', 'Service Template href e.g. https://1.1.1.94/api/service_templates/1') do |template_href|
+    options[:template_href] = template_href
+  end
+
+  opts.on('-n', '--no_cert_check', 'Disable certificate check') do
+    options[:verify_ssl] = false
+  end
+
+  opts.on('-q', '--quota_check', 'Enable quota check, disabled by default') do
+    options[:quota_check] = true
+  end
+
+  opts.on('-h', '--help', 'Displays Help') do
+    puts opts
+    exit
+  end
+end
+
+parser.parse!
+if options[:template].nil? && options[:template_href].nil?
+  puts "template or template_href is required"
+  puts parser
+  exit 1
+end
+
+pwd = Dir.pwd
+%w(Dockerfile Makefile apb.yml).each do |f|
+  filename = File.join(pwd, f)
+  raise "#{filename} not found please ensure you are running this from apb directory" unless File.exist?(filename)
+end
+
+%w(playbooks roles).each do |d|
+  dirname = File.join(pwd, d)
+  raise "#{dirname} not found please ensure you are running this from apb directory" unless Dir.exist?(dirname)
+end
+
+ServiceTemplateToAPB.new(options).convert
+ApprovalToAPB.new(options).convert

--- a/role_templates/manageiq-approval/defaults/main.yml
+++ b/role_templates/manageiq-approval/defaults/main.yml
@@ -1,0 +1,12 @@
+---
+# defaults file for manageiq-approval
+rules_engine_get_path: /kie-server/services/rest/server/queries/processes/instances
+rules_engine_post_path: /kie-server/services/rest/server/containers/servicecatalog/processes/apprvoal.ServiceCatalogApproval/instances
+rules_engine_base_url: "{{ bpms_base_url }}"
+rules_engine_post_href: "{{ rules_engine_base_url }}{{ rules_engine_post_path }}"
+rules_engine_get_href:  "{{ rules_engine_base_url }}{{ rules_engine_get_path }}"
+rules_engine_user: "{{ bpms_username }}"
+rules_engine_password: "{{ bpms_password }}"
+rules_engine_retries: "{{ bpms_max_retries }}"
+rules_engine_delay: "{{ bpms_retry_interval }}"
+rules_engine_validate_certs: "{{ bpms_validate_certs | True }}"

--- a/role_templates/manageiq-approval/tasks/main.yml
+++ b/role_templates/manageiq-approval/tasks/main.yml
@@ -1,0 +1,99 @@
+---
+# tasks file for manageiq-approval
+- name: preliminary login information with account that can see everything
+  raw: "oc login -u developer -p asd && oc project {{ namespace }}"
+
+- name: list service instances
+  raw: oc get serviceinstances -o json
+  register: serviceinstances
+
+  # We need to rename the returned item as a generic list since oc is returning a
+  #   reserved key of 'items'
+- set_fact:
+    services_all: "{{ (serviceinstances.stdout | from_json)['items'] }}"
+
+- name: "get serviceclass labels for {{ _apb_service_class_id }}"
+  raw: "oc get clusterserviceclass {{ _apb_service_class_id }} -o json"
+  register: serviceclass
+
+- debug: msg="Services All {{ services_all }}"
+
+- debug: msg="Service Class {{ serviceclass.stdout }}"
+
+- name: "pull username from service instance id {{ _apb_service_instance_id }}"
+  with_items: "{{ services_all }}"
+  set_fact: 
+    username: "{{ item.spec.userInfo.username }}"
+    project: "{{ item.metadata.namespace }}"
+  when: item.spec.externalID == _apb_service_instance_id
+
+- debug: msg="Username- {{ username }} Project - {{ project }}"
+
+- name: "dump oc project {{ project }}"
+  raw: "oc get project {{ project }} -o json"
+  register: project_json
+
+- name: "dump oc user {{ username }}"
+  raw: "oc get user {{ username }} -o json"
+  register: username_json
+
+- set_fact:
+    service_class_labels: "{{ (serviceclass.stdout | from_json).metadata.labels | default('No Labels') }}"
+    project_labels: "{{ (project_json.stdout | from_json).metadata.labels | default('No Labels') }}"
+    username_labels: "{{ (username_json.stdout | from_json).metadata.labels | default('No Labels') }}"
+    username_name: "{{ (username_json.stdout | from_json).metadata.name | default('No Name') }}"
+    service_class_name: "{{ (serviceclass.stdout | from_json).metadata.name | default('No Name') }}"
+
+- debug: msg="Service Class Labels for {{ (serviceclass.stdout | from_json).metadata.name}} {{ service_class_labels }}"
+- debug: msg="Project Labels for {{ (project_json.stdout | from_json).metadata.name }} {{ project_labels }}"
+- debug: msg="Username Labels for {{ (username_json.stdout | from_json).metadata.name}} {{ username_labels }}"
+- debug: msg="Username Name for {{ (username_json.stdout | from_json).metadata.name}} {{ username_name }}"
+- debug: msg="Service Class Name for {{ (serviceclass.stdout | from_json).metadata.name}} {{ service_class_name }}"
+
+- name: POST the Approval Rules engine with this service
+  uri:
+    url: "{{ rules_engine_post_href }}"
+    user: "{{ rules_engine_user }}"
+    password: "{{ rules_engine_password }}"
+    force_basic_auth: yes
+    method: POST
+    validate_certs: "{{ rules_engine_validate_certs }}"
+    headers:
+      X-KIE-ContentType: "JSON"
+      Content-Type: "application/json"
+      Accept: "application/json"
+    body_format: json
+    status_code: 201
+    body:
+      userLabel: "{{ username_labels.permissions }}"
+      projectLabel: "{{ project_labels.permissions }}"
+      serviceLabel: "{{ service_class_labels.permissions }}"
+      requesterName: "{{ username_name }}"
+      serviceName: "{{ service_class_name }}"
+      approvalStatus: "Pending"
+    return_content: yes
+  register: rule_instance
+
+- debug: msg="Rule instance {{ rule_instance }}"
+
+- name: GET the approval process status
+  uri:
+    url: "{{ rules_engine_get_href }}/{{ rule_instance.content }}?withVars=true"
+    method: GET
+    user: "{{ rules_engine_user }}"
+    password: "{{ rules_engine_password }}"
+    force_basic_auth: yes
+    validate_certs: "{{ rules_engine_validate_certs }}"
+    headers:
+      X-KIE-ContentType: "JSON"
+      Content-Type: "application/json"
+      Accept: "application/json"
+    body_format: json
+    status_code: 200
+  register: approval_request
+  until: approval_request.json['process-instance-variables'].approvalStatus == 'Approved' or approval_request.json['process-instance-variables'].approvalStatus == 'Denied'
+  failed_when: approval_request.json['process-instance-variables'].approvalStatus != 'Approved'
+  retries: "{{ rules_engine_retries }}"
+  delay: "{{ rules_engine_delay }}"
+
+- debug: var=approval_request.json['process-instance-variables'].approvalStatus


### PR DESCRIPTION
1. Rename the tool to miq_apb to pull options logic away from apb logic
2. Add `ApprovalToAPB` class to install the [manageiq-approval](https://github.com/syncrou/manageiq-approval) role and modify `playbooks/provision.yml` to use the approval role

Help Outputs the following options:

```
ruby ~/syncrou/miq_apb_tool/miq_apb.rb
template or template_href is required
Converts Cloudforms service template to APB.
Usage: miq_apb.rb [options]
    -u, --user <<user>>              CFME User default: admin
    -p, --password <<password>>      CFME Password default: smartvm
    -s, --url <<url>>                CFME Server URL default: http://localhost:4000
    -t, --template <<name>>          Service Template e.g. CFME_RHEV
    -r, --template_href <<url>>      Service Template href e.g. https://1.1.1.94/api/service_templates/1
    -n, --no_cert_check              Disable certificate check
    -q, --quota_check                Enable quota check, disabled by default
    -h, --help                       Displays Help
```